### PR TITLE
add enrichment api

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ client := kagi.NewClient(&kagi.ClientConfig{
 ```go
 response, err := client.FastGPTCompletion(kagi.FastGPTCompletionParams{
     Query:     "query",
-    WebSearch: false,
+    WebSearch: true,
     Cache:     true,
 })
 if err != nil {
@@ -46,4 +46,17 @@ if err != nil {
     return
 }
 fmt.Println(response.Data.Output)
+```
+
+### Enrichment
+
+```go
+response, err := client.EnrichmentCompletion(kagi.EndpointTypeWeb, kagi.EnrichmentParams{
+    Q: "kagi search",
+})
+if err != nil {
+    fmt.Println(err)
+    return
+}
+fmt.Println(response.Data)
 ```

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/httpjamesm/kagigo/constants"
+	"github.com/httpjamesm/kagigo/types"
 )
 
 type ClientConfig struct {
@@ -71,14 +72,13 @@ func (c *Client) SendRequest(method, path string, data interface{}, v any) (err 
 	}
 
 	if resp.StatusCode() != 200 {
-		var res UniversalSummarizerResponse
-		err := json.Unmarshal(resp.Body(), &res)
-		if err != nil || len(res.Errors) == 0 {
+		var apiError types.ErrorResponse
+		err := json.Unmarshal(resp.Body(), &apiError)
+		if err != nil || len(apiError.Error) == 0 {
 			return fmt.Errorf("received status code %d with unparseable error response", resp.StatusCode())
 		}
-		errObj := res.Errors[0]
 		return fmt.Errorf("received status code %d. error object: %v", resp.StatusCode(),
-			fmt.Sprintf("[code: %d, msg: %s, ref: %v]", errObj.Code, errObj.Msg, errObj.Ref))
+			fmt.Sprintf("[code: %d, msg: %s, ref: %v]", apiError.Error[0].Code, apiError.Error[0].Msg, apiError.Error[0].Ref))
 	}
 
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -59,6 +59,7 @@ func (c *Client) SendRequest(method, path string, data interface{}, v any) (err 
 
 	switch method {
 	case "GET":
+		reqBuild.SetQueryParams(data.(map[string]string)) // enrichment api requires query params
 		resp, err = reqBuild.Get(baseURL + path)
 	case "POST":
 		resp, err = reqBuild.Post(baseURL + path)

--- a/enrichment.go
+++ b/enrichment.go
@@ -40,16 +40,16 @@ func (c *Client) EnrichmentCompletion(endpointType string, params EnrichmentPara
 	}
 
 	if endpointType == "" {
-		err = fmt.Errorf("endpoint_type is required")
+		err = fmt.Errorf("endpoint type is required")
 		return
 	}
 
 	if endpointType != EndpointTypeWeb && endpointType != EndpointTypeNews {
-		err = fmt.Errorf("endpoint_type must be web or news")
+		err = fmt.Errorf("endpoint type must be EndpointTypeWeb or EndpointTypeNews")
 		return
 	}
 
-	// needed to set query parameters in client.go
+	// needed to set as a query parameter in client.go
 	paramsMap := make(map[string]string)
 	paramsMap["q"] = params.Q
 

--- a/enrichment.go
+++ b/enrichment.go
@@ -16,10 +16,10 @@ type EnrichmentParams struct {
 
 type EnrichmentResponse struct {
 	Meta struct {
-		ID   string `json:"id"`
-		Node string `json:"node"`
-		Ms   int    `json:"ms"`
-		API  string `json:"api_balance"`
+		ID   string  `json:"id"`
+		Node string  `json:"node"`
+		Ms   int     `json:"ms"`
+		API  float64 `json:"api_balance"`
 	} `json:"meta"`
 	Data []struct {
 		T         int      `json:"t"`
@@ -49,12 +49,15 @@ func (c *Client) EnrichmentCompletion(endpointType string, params EnrichmentPara
 		return
 	}
 
-	err = c.SendRequest("GET", "/enrich/"+endpointType, params, &res)
+	// needed to set query parameters in client.go
+	paramsMap := make(map[string]string)
+	paramsMap["q"] = params.Q
+
+	err = c.SendRequest("GET", "/enrich/"+endpointType, paramsMap, &res)
 	if err != nil {
 		return
 	}
 
-	// will this ever happen here?
 	if len(res.Errors) != 0 {
 		errObj := res.Errors[0]
 		err = fmt.Errorf("api returned error: %v", fmt.Sprintf("[code: %d, msg: %s, ref: %v]", errObj.Code, errObj.Msg, errObj.Ref))

--- a/enrichment.go
+++ b/enrichment.go
@@ -1,0 +1,65 @@
+package kagi
+
+import (
+	"fmt"
+	"github.com/httpjamesm/kagigo/types"
+)
+
+const (
+	EndpointTypeWeb  string = "web"
+	EndpointTypeNews string = "news"
+)
+
+type EnrichmentParams struct {
+	Q string `json:"q"`
+}
+
+type EnrichmentResponse struct {
+	Meta struct {
+		ID   string `json:"id"`
+		Node string `json:"node"`
+		Ms   int    `json:"ms"`
+		API  string `json:"api_balance"`
+	} `json:"meta"`
+	Data []struct {
+		T         int      `json:"t"`
+		Rank      int      `json:"rank"`
+		URL       string   `json:"url"`
+		Title     string   `json:"title"`
+		Snippet   string   `json:"snippet"`
+		Published string   `json:"published"`
+		List      []string `json:"list"`
+	} `json:"data"`
+	Errors []types.Error `json:"error"`
+}
+
+func (c *Client) EnrichmentCompletion(endpointType string, params EnrichmentParams) (res EnrichmentResponse, err error) {
+	if params.Q == "" {
+		err = fmt.Errorf("query is required")
+		return
+	}
+
+	if endpointType == "" {
+		err = fmt.Errorf("endpoint_type is required")
+		return
+	}
+
+	if endpointType != EndpointTypeWeb && endpointType != EndpointTypeNews {
+		err = fmt.Errorf("endpoint_type must be web or news")
+		return
+	}
+
+	err = c.SendRequest("GET", "/enrich/"+endpointType, params, &res)
+	if err != nil {
+		return
+	}
+
+	// will this ever happen here?
+	if len(res.Errors) != 0 {
+		errObj := res.Errors[0]
+		err = fmt.Errorf("api returned error: %v", fmt.Sprintf("[code: %d, msg: %s, ref: %v]", errObj.Code, errObj.Msg, errObj.Ref))
+		return
+	}
+
+	return
+}

--- a/enrichment_test.go
+++ b/enrichment_test.go
@@ -1,0 +1,75 @@
+package kagi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/httpjamesm/kagigo/constants"
+)
+
+func TestEnrichment(t *testing.T) {
+	apiToken := os.Getenv("KAGI_API_TOKEN")
+
+	client := NewClient(&ClientConfig{
+		APIKey:     apiToken,
+		APIVersion: constants.CurrentApiVersion,
+	})
+
+	params := EnrichmentParams{
+		Q: "kagi search",
+	}
+
+	// test EndpointType exists error
+	res, err := client.EnrichmentCompletion("", params)
+	if err == nil {
+		t.Errorf("Expected endpoint type is required error, got nil")
+	}
+
+	// test EndpointType must be web or news error
+	res, err = client.EnrichmentCompletion("unexpected", params)
+	if err == nil {
+		t.Errorf("Expected endpoint type must be web or news error, got nil")
+	}
+
+	// test news endpoint does not return error
+	res, err = client.EnrichmentCompletion("news", EnrichmentParams{
+		Q: "los angeles",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// test web endpoint does not return error
+	res, err = client.EnrichmentCompletion("web", params)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Check the response fields
+	if res.Meta.ID == "" {
+		t.Errorf("Expected non-empty ID, got '%s'", res.Meta.ID)
+	}
+
+	if res.Meta.Node == "" {
+		t.Errorf("Expected non-empty Node, got '%s'", res.Meta.Node)
+	}
+
+	if res.Meta.Ms < 0 {
+		t.Errorf("Expected positive Ms, got '%d'", res.Meta.Ms)
+	}
+
+	if res.Data == nil {
+		t.Errorf("Expected non-empty Data object, got '%v'", res.Data)
+	}
+
+	if res.Data[0].URL == "" || res.Data[0].Title == "" || res.Data[0].Snippet == "" {
+		t.Errorf("Expected URL, Title, Snippet, got '%v'", res.Data[0])
+	}
+
+	// test if query is empty
+	params.Q = ""
+	res, err = client.EnrichmentCompletion("web", params)
+	if err == nil {
+		t.Errorf("Expected query is required error, got nil")
+	}
+}

--- a/enrichment_test.go
+++ b/enrichment_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/httpjamesm/kagigo/constants"
 )
 
-func TestEnrichment(t *testing.T) {
+func TestEnrichmentCompletion(t *testing.T) {
 	apiToken := os.Getenv("KAGI_API_TOKEN")
 
 	client := NewClient(&ClientConfig{

--- a/types/error.go
+++ b/types/error.go
@@ -5,3 +5,9 @@ type Error struct {
 	Msg  string      `json:"msg"`
 	Ref  interface{} `json:"ref"`
 }
+
+type ErrorResponse struct {
+	Meta  interface{} `json:"meta"`
+	Data  interface{} `json:"data"`
+	Error []Error     `json:"error"`
+}


### PR DESCRIPTION
Adds the Enrichment API

Other minor changes: adds generic error response struct and updates fastgpt quickstart example [to not fail](https://help.kagi.com/kagi/api/fastgpt.html#parameters)